### PR TITLE
Fix t100 detection

### DIFF
--- a/config/printers/t100.cfg
+++ b/config/printers/t100.cfg
@@ -1,4 +1,5 @@
-[include fluidd.cfg]
+#[include fluidd.cfg]
+[include ../../mainsail.cfg]
 [include ../boards/btt-skr-pico/config.cfg]
 [include ../fans/part_fan_dual.cfg]
 [include ../fans/hotend_fan.cfg]

--- a/config/printers/t100.cfg
+++ b/config/printers/t100.cfg
@@ -22,6 +22,8 @@
 [include ../extruders/bmg-bowden.cfg]
 [include ../hotends/chc-pro.cfg]
 [include ../boards/fysetc-pis/config.cfg]
+[include ../lights/neopixel_light_bar.cfg]
+
 
 [virtual_sdcard]
 path: /home/klipper/printer_data/gcodes

--- a/config/printers/t100.cfg
+++ b/config/printers/t100.cfg
@@ -8,7 +8,7 @@
 [include ../kinematics/corexy.cfg]
 [include ../axis/X/default_configuration.cfg]
 [include ../axis/Y/default_configuration.cfg]
-[include ../axis/Z/default_wiring_1M.cfg]
+[include ../axis/Z/default_TR8x8_1.8deg.cfg
 [include ../beds/ender-2-pro/size.cfg]
 [include ../beds/ender-2-pro/config.cfg]
 [include ../beds/ender-2-pro/manual-leveling-t100.cfg]

--- a/config/printers/t100.cfg
+++ b/config/printers/t100.cfg
@@ -8,7 +8,7 @@
 [include ../kinematics/corexy.cfg]
 [include ../axis/X/default_configuration.cfg]
 [include ../axis/Y/default_configuration.cfg]
-[include ../axis/Z/default_TR8x8_1.8deg.cfg
+[include ../axis/Z/default_TR8x8_1.8deg.cfg]
 [include ../beds/ender-2-pro/size.cfg]
 [include ../beds/ender-2-pro/config.cfg]
 [include ../beds/ender-2-pro/manual-leveling-t100.cfg]

--- a/scripts/install-printer-cfg.sh
+++ b/scripts/install-printer-cfg.sh
@@ -22,7 +22,7 @@ if [[ -f "$AVAHI_PATH" ]]; then
     debug "Avahi configuration file found at $AVAHI_PATH."
 
     # Extract the value of host-name and remove whitespace
-    debug=$(grep -E "^\s*host-name\s*=" "$AVAHI_PATH" | sed -E 's/.*=\s*//;s/\s*$//')
+    VALUE=$(grep -E "^\s*host-name\s*=" "$AVAHI_PATH" | sed -E 's/.*=\s*//;s/\s*$//')
     debug "Extracted host-name value: '$VALUE'"
 
     # Check if VALUE is set


### PR DESCRIPTION
The check for the decicion to install a t100 or t250 does not work. Issue is the use of a the wrong return value and then it falls back to the default of t250.

The code assume that the hostname check return an entry into the variable VALUE, but it gives it back into the variable debug.

Fixing the variable name from "debug" to the right name "VALUE" fixes the detection.