### PR TITLE
feat: Add BTT Kraken V1.1 board

### DIFF
--- a/config/boards/btt-kraken-v11/98-btt-kraken.rules
+++ b/config/boards/btt-kraken-v11/98-btt-kraken.rules
@@ -1,0 +1,2 @@
+# BTT Kraken
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="614e",  ATTRS{idVendor}=="1d50", ATTRS{serial}=="btt-kraken", ACTION=="add", SYMLINK+="btt-kraken", RUN+="/home/pi/printer_data/config/config/scripts/klipper-mcu-added.sh"

--- a/config/boards/btt-kraken-v11/config.cfg
+++ b/config/boards/btt-kraken-v11/config.cfg
@@ -1,0 +1,93 @@
+#--------------------------------------#
+##### BTT Kraken MCU definition ########
+#--------------------------------------#
+
+[board_pins kraken]
+aliases:
+     X_STEP=PC14    ,  X_DIR=PC13    ,  X_ENABLE=PE6     ,  X_UART=PD6    ,  X_STOP=PC15    , # X-Motor Front Left
+    X1_STEP=PE5     , X1_DIR=PE4     , X1_ENABLE=PE3     , X1_UART=PD5    ,                   # X-Motor Back Right
+     Y_STEP=PE2     ,  Y_DIR=PE1     ,  Y_ENABLE=PE0     ,  Y_UART=PD4    ,  Y_STOP=PF1     , # Y-Motor Front Right
+    Y1_STEP=PB9     , Y1_DIR=PB8     , Y1_ENABLE=PB7     , Y1_UART=PD3    ,                   # Y-Motor Back Right
+     E_STEP=PG9     ,  E_DIR=PG10    ,  E_ENABLE=PG13    ,  E_UART=PD2    ,                   # Extruder
+     Z_STEP=PG11    ,  Z_DIR=PD7     ,  Z_ENABLE=PG12    ,  Z_UART=PA15   ,                   # Z-Motor Front Left
+    Z1_STEP=PB4     , Z1_DIR=PB3     , Z1_ENABLE=PB5     , Z1_UART=PA9    ,                   # Z-Motor Front Right
+    Z2_STEP=PG15    , Z2_DIR=PB6     , Z2_ENABLE=PG14    , Z2_UART=PA10   ,                   # Z-Motor Back
+
+# Stepper SPI
+    DRIVER_SPI_MOSI=PC8 , DRIVER_SPI_MISO=PC7  , DRIVER_SPI_SCK=PC6     ,
+
+# Hotend & Heatbed
+    E_HEATER=PF6        , E_TEMPERATURE=PB1    ,
+    BED_HEATER=PF5      , BED_TEMPERATURE=PB0  ,
+
+# Fans
+    PART_FAN=PA0        , E_FAN=PA1            ,
+    MOTOR_FAN=PA2       , MOTOR_TEMPERATURE=PC5,
+    ELECTRONIC_FAN=PA3  ,
+    SIDE_FAN_LEFT=PA4   , SIDE_FAN_RIGHT=PA5   ,
+
+# Micro Probe (BDSensor / BlTouch)
+    PROBE_SENSOR=PG1    , PROBE_CONTROL=PE9    ,
+
+# RGB
+    LIGHT=PF12          ,
+
+[mcu]
+serial: /dev/btt-kraken
+cpu: stm32h723xx
+
+[tmc5160 stepper_x]
+cs_pin: X_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_4.7A
+
+[tmc5160 stepper_x1]
+cs_pin: X1_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_4.7A
+
+[tmc5160 stepper_y]
+cs_pin: Y_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_4.7A
+
+[tmc5160 stepper_y1]
+cs_pin: Y1_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_4.7A
+
+[tmc5160 extruder]
+cs_pin: E_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_3A
+
+[tmc5160 stepper_z]
+cs_pin: Z_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_3A
+
+[tmc5160 stepper_z1]
+cs_pin: Z1_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_3A
+
+[tmc5160 stepper_z2]
+cs_pin: Z2_UART
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+stepstick_type: KRAKEN_2160_3A

--- a/config/templates/t250.cfg
+++ b/config/templates/t250.cfg
@@ -7,6 +7,8 @@
 
 # Board
 [include config/boards/btt-kraken/config.cfg]
+# Use this line if you have the new V1.1 revision of the Kraken
+# [include config/boards/btt-kraken-v11/config.cfg]
 
 # Fans
 [include config/fans/part_fan_cpap.cfg]


### PR DESCRIPTION
The only change from the 1.0 revision is a different sense resistor installed for the primary four stepper drivers.

We intentionally don't default to the new version in the T250 template so at worst a lower sense resistor is physically present (V1.0: 22 mOhm) on the board than defined in our config (V1.1: 50 mOhm). The other way around could lead to damaging currents getting supplied to the motors.

Depends on https://github.com/MSzturc/klipper/pull/1.

Untested since I haven't build the printer yet...